### PR TITLE
Add additional data to PageData method

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,7 +73,10 @@ func (cl *Client) PagesData(ctx context.Context, titles ...string) (map[string]P
 	res := new(pageDataResponse)
 	body := url.Values{
 		"action":        []string{"query"},
-		"prop":          []string{"pageprops|info|revisions"},
+		"prop":          []string{"info|categories|revisions|templates|wbentityusage|pageprops|redirects"},
+		"rvprop":        []string{"comment|oresscores|content|ids|timestamp|tags|user"},
+		"rvslots":       []string{"main"},
+		"inprop":        []string{"displaytitle|protection|url"},
 		"ppprop":        []string{"wikibase_item"},
 		"redirects":     []string{"1"},
 		"titles":        []string{strings.Join(titles, "|")},
@@ -99,9 +102,7 @@ func (cl *Client) PagesData(ctx context.Context, titles ...string) (map[string]P
 		return pages, fmt.Errorf(errBadRequestMsg, status, data)
 	}
 
-	err = json.Unmarshal(data, res)
-
-	if err != nil {
+	if err := json.Unmarshal(data, res); err != nil {
 		return pages, err
 	}
 

--- a/example/main.go
+++ b/example/main.go
@@ -69,4 +69,12 @@ func main() {
 	}
 
 	fmt.Println(string(wikitext))
+
+	pdata, err := client.PagesData(ctx, "Barack_Obama")
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	fmt.Println(pdata["Barack_Obama"])
 }

--- a/page_data.go
+++ b/page_data.go
@@ -6,13 +6,9 @@ const pageDataURL = "/w/api.php"
 
 // PageData page data returned from actions API
 type PageData struct {
-	PageID    int    `json:"pageid"`
-	Ns        int    `json:"ns"`
-	Title     string `json:"title"`
-	Missing   bool   `json:"missing"`
-	Pageprops struct {
-		WikibaseItem string `json:"wikibase_item"`
-	} `json:"pageprops"`
+	PageID               int       `json:"pageid"`
+	Ns                   int       `json:"ns"`
+	Title                string    `json:"title"`
 	ContentModel         string    `json:"contentmodel"`
 	PageLanguage         string    `json:"pagelanguage"`
 	PageLanguageHTMLCode string    `json:"pagelanguagehtmlcode"`
@@ -20,14 +16,64 @@ type PageData struct {
 	Touched              time.Time `json:"touched"`
 	LastRevID            int       `json:"lastrevid"`
 	Length               int       `json:"length"`
-	Revisions            []struct {
+	Missing              bool      `json:"missing"`
+	Protection           []struct {
+		Type   string `json:"type"`
+		Level  string `json:"level"`
+		Expiry string `json:"expiry"`
+	} `json:"protection"`
+	Restrictiontypes []string `json:"restrictiontypes"`
+	FullURL          string   `json:"fullurl"`
+	EditURL          string   `json:"editurl"`
+	CanonicalURL     string   `json:"canonicalurl"`
+	Displaytitle     string   `json:"displaytitle"`
+	Categories       []struct {
+		Ns    int    `json:"ns"`
+		Title string `json:"title"`
+	} `json:"categories"`
+	Revisions []struct {
 		RevID     int       `json:"revid"`
 		ParentID  int       `json:"parentid"`
-		Minor     bool      `json:"minor"`
 		User      string    `json:"user"`
 		Timestamp time.Time `json:"timestamp"`
-		Comment   string    `json:"comment"`
+		Slots     struct {
+			Main struct {
+				Contentmodel  string `json:"contentmodel"`
+				Contentformat string `json:"contentformat"`
+				Content       string `json:"content"`
+			} `json:"main"`
+		} `json:"slots"`
+		Comment    string   `json:"comment"`
+		Tags       []string `json:"tags"`
+		Oresscores struct {
+			Articlequality struct {
+				Stub float64 `json:"Stub"`
+			} `json:"articlequality"`
+			Damaging struct {
+				True  float64 `json:"true"`
+				False float64 `json:"false"`
+			} `json:"damaging"`
+			Goodfaith struct {
+				True  float64 `json:"true"`
+				False float64 `json:"false"`
+			} `json:"goodfaith"`
+		} `json:"oresscores"`
 	} `json:"revisions"`
+	Templates []struct {
+		Ns    int    `json:"ns"`
+		Title string `json:"title"`
+	} `json:"templates"`
+	WbEntityUsage map[string]struct {
+		Aspects []string `json:"aspects"`
+	} `json:"wbentityusage"`
+	Pageprops struct {
+		WikibaseItem string `json:"wikibase_item"`
+	} `json:"pageprops"`
+	Redirects []struct {
+		PageID int    `json:"pageid"`
+		Ns     int    `json:"ns"`
+		Title  string `json:"title"`
+	} `json:"redirects"`
 }
 
 type pageDataResponse struct {


### PR DESCRIPTION
Extend `PageData` method to return wikitext and other additional data for schema exspansion.