### PR TITLE
Add users API and updated Page Data

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -17,6 +17,7 @@ const builderTestSitematrixURL = "/sitematrix"
 const builderTestNamespacesURL = "/namespaces"
 const builderTestPageRevisionsURL = "/revisions"
 const builderTestPagesDataURL = "/pages-data"
+const builderTestUserURL = "/users"
 
 func TestBuilder(t *testing.T) {
 	builder := NewBuilder(builderTestURL).
@@ -35,6 +36,7 @@ func TestBuilder(t *testing.T) {
 			builderTestSitematrixURL,
 			builderTestNamespacesURL,
 			builderTestPagesDataURL,
+			builderTestUserURL,
 		})
 
 	client := builder.Build()
@@ -48,5 +50,6 @@ func TestBuilder(t *testing.T) {
 	assert.Equal(t, builderTestSitematrixURL, client.options.SitematrixURL)
 	assert.Equal(t, builderTestNamespacesURL, client.options.NamespacesURL)
 	assert.Equal(t, builderTestPagesDataURL, client.options.PageDataURL)
+	assert.Equal(t, builderTestUserURL, client.options.UserURL)
 	assert.Equal(t, builderTestTimeout, client.httpClient.Timeout)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -70,11 +70,27 @@ func main() {
 
 	fmt.Println(string(wikitext))
 
-	pdata, err := client.PagesData(ctx, "Barack_Obama")
+	pdata, err := client.PageData(ctx, "barack_Obama")
 
 	if err != nil {
 		log.Panic(err)
 	}
 
-	fmt.Println(pdata["Barack_Obama"])
+	fmt.Println(pdata)
+
+	users, err := client.Users(ctx, pdata.Revisions[0].UserID, 3333333)
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	fmt.Println(users)
+
+	user, err := client.User(ctx, pdata.Revisions[0].UserID)
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	fmt.Println(user)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -70,7 +70,15 @@ func main() {
 
 	fmt.Println(string(wikitext))
 
-	pdata, err := client.PageData(ctx, "barack_Obama")
+	psdata, err := client.PagesData(ctx, "Barack_Obama", "Earth")
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	fmt.Println(psdata)
+
+	pdata, err := client.PageData(ctx, "Barack_Obama")
 
 	if err != nil {
 		log.Panic(err)

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/options.go
+++ b/options.go
@@ -9,4 +9,5 @@ type Options struct {
 	SitematrixURL    string
 	NamespacesURL    string
 	PageDataURL      string
+	UserURL          string
 }

--- a/page_data.go
+++ b/page_data.go
@@ -24,6 +24,7 @@ type PageDataRevision struct {
 	RevID     int       `json:"revid"`
 	ParentID  int       `json:"parentid"`
 	User      string    `json:"user"`
+	UserID    int       `json:"userid"`
 	Minor     bool      `json:"minor"`
 	Timestamp time.Time `json:"timestamp"`
 	Slots     struct {

--- a/user.go
+++ b/user.go
@@ -1,0 +1,24 @@
+package mediawiki
+
+import "time"
+
+const userURL = "/w/api.php"
+
+// User mediawiki user representation.
+type User struct {
+	UserID           int           `json:"userid,omitempty"`
+	Name             string        `json:"name"`
+	EditCount        int           `json:"editcount,omitempty"`
+	Registration     time.Time     `json:"registration,omitempty"`
+	Groups           []string      `json:"groups,omitempty"`
+	GroupMemberships []interface{} `json:"groupmemberships,omitempty"`
+	Emailable        bool          `json:"emailable,omitempty"`
+	Missing          bool          `json:"missing,omitempty"`
+}
+
+type userResponse struct {
+	Batchcomplete bool `json:"batchcomplete"`
+	Query         struct {
+		Users []User `json:"users"`
+	} `json:"query"`
+}

--- a/usert_test.go
+++ b/usert_test.go
@@ -1,0 +1,90 @@
+package mediawiki
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const userTestURL = "/user"
+const userTestID = 100
+const userTestMissingID = 999
+const userTestName = "Ninja"
+const userTestEditCount = 2
+const userTestBody = `{
+	"batchcomplete": true,
+	"query": {
+			"users": [
+					{
+							"userid": %d,
+							"name": "%s",
+							"editcount": %d,
+							"registration": "2021-04-02T13:43:05Z",
+							"groups": [
+									"*",
+									"user",
+									"autoconfirmed"
+							],
+							"groupmemberships": [],
+							"emailable": false
+					},
+					{
+							"userid": %d,
+							"missing": true
+					}
+			]
+	}
+}`
+
+func createUserServer() http.Handler {
+	router := http.NewServeMux()
+
+	router.HandleFunc(userTestURL, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(fmt.Sprintf(
+			userTestBody,
+			userTestID,
+			userTestName,
+			userTestEditCount,
+			userTestMissingID)))
+	})
+
+	return router
+}
+
+func assertUser(assert *assert.Assertions, user User) {
+	assert.Equal(userTestID, user.UserID)
+	assert.Equal(userTestName, user.Name)
+	assert.Equal(userTestEditCount, user.EditCount)
+	assert.NotEmpty(user.Groups)
+}
+
+func TestUser(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	srv := httptest.NewServer(createUserServer())
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	client.options.UserURL = userTestURL
+
+	users, err := client.Users(ctx, userTestID, userTestMissingID)
+	assert.NoError(err)
+	assert.Contains(users, userTestID)
+	assert.NotContains(users, userTestMissingID)
+
+	for id, user := range users {
+		assert.Equal(userTestID, id)
+		assertUser(assert, user)
+	}
+
+	_, err = client.User(ctx, userTestMissingID)
+	assert.Equal(ErrUserNotFound, err)
+
+	user, err := client.User(ctx, userTestID)
+	assert.NoError(err)
+	assertUser(assert, user)
+}


### PR DESCRIPTION
- Add `PageData` method to get a single page data instead of many.
- Add `Users` method to query multiple users by id at once
- Add `User` method to query single user by id