### PR TITLE
Add support for revisions ordering.

### DIFF
--- a/client.go
+++ b/client.go
@@ -210,9 +210,15 @@ func (cl *Client) PageWikitext(ctx context.Context, title string, rev ...int) ([
 }
 
 // PageRevisions get list of page revisions.
-func (cl *Client) PageRevisions(ctx context.Context, title string, limit int) ([]Revision, error) {
+func (cl *Client) PageRevisions(ctx context.Context, title string, limit int, order ...RevisionOrdering) ([]Revision, error) {
 	revs := []Revision{}
-	data, status, err := req(ctx, cl.httpClient, http.MethodGet, cl.url+fmt.Sprintf(cl.options.PageRevisionsURL, limit, url.QueryEscape(title)), nil)
+
+	ordering := RevisionOrderingOlder
+	if len(order) > 0 {
+		ordering = order[0]
+	}
+
+	data, status, err := req(ctx, cl.httpClient, http.MethodGet, cl.url+fmt.Sprintf(cl.options.PageRevisionsURL, limit, ordering, url.QueryEscape(title)), nil)
 
 	if err != nil {
 		return revs, err

--- a/example/main.go
+++ b/example/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	fmt.Println(string(data))
 
-	revisions, err := client.PageRevisions(ctx, "Pet_door", 10)
+	revisions, err := client.PageRevisions(ctx, "Pet_door", 10, mediawiki.RevisionOrderingOlder)
 
 	if err != nil {
 		log.Panic(err)

--- a/page_revisions.go
+++ b/page_revisions.go
@@ -2,7 +2,7 @@ package mediawiki
 
 import "time"
 
-const revisionsURL = "/w/api.php?action=query&format=json&prop=revisions&rvlimit=%d&formatversion=2&titles=%s"
+const revisionsURL = "/w/api.php?action=query&format=json&prop=revisions&rvlimit=%d&rvdir=%s&formatversion=2&titles=%s"
 
 // Revision page revision schema
 type Revision struct {
@@ -14,6 +14,16 @@ type Revision struct {
 	Comment   string    `json:"comment"`
 	Anon      bool      `json:"anon,omitempty"`
 }
+
+// RevisionOrdering specifies the direction to enumerate the revisions list
+type RevisionOrdering string
+
+const (
+	// RevisionOrderingOlder lists newest revision first (default)
+	RevisionOrderingOlder RevisionOrdering = "older"
+	// RevisionOrderingNewer lists oldest revision first
+	RevisionOrderingNewer RevisionOrdering = "newer"
+)
 
 type revisionsResponse struct {
 	Batchcomplete bool                         `json:"batchcomplete"`

--- a/page_revisions_test.go
+++ b/page_revisions_test.go
@@ -13,14 +13,17 @@ import (
 
 var pageRevisionsTestIDS = []int{944917628, 944912305}
 
-const pageRevisionsTestURL = "/revisions/%d/%s"
-const pageRevisionsTestTitle = "test"
-const pageRevisionsTestLimit = 2
+const (
+	pageRevisionsTestURL   = "/revisions/%d/%s/%s"
+	pageRevisionsTestTitle = "test"
+	pageRevisionsTestLimit = 2
+	pageRevisionsTestOrder = RevisionOrderingNewer
+)
 
 func createPageRevisionsServer() http.Handler {
 	router := http.NewServeMux()
 
-	router.HandleFunc(fmt.Sprintf(pageRevisionsTestURL, pageRevisionsTestLimit, pageRevisionsTestTitle), func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc(fmt.Sprintf(pageRevisionsTestURL, pageRevisionsTestLimit, pageRevisionsTestOrder, pageRevisionsTestTitle), func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(fmt.Sprintf(`{"continue":{"rvcontinue":"20200310174438|944912225","continue":"||"},"query":{"normalized":[{"fromencoded":false,"from":"Pet_door","to":"Pet door"}],"pages":[{"pageid":3276454,"ns":0,"title":"%s","revisions":[{"revid":%d,"parentid":944912305,"minor":true,"user":"IdreamofJeanie","timestamp":"2020-03-10T18:17:36Z","comment":"Reverted 2 edits by [[Special:Contributions\/112.196.52.43|112.196.52.43]] ([[User talk:112.196.52.43|talk]]) to last revision by LizzieBabes419 ([[WP:TW|TW]])"},{"revid":%d,"parentid":944912225,"minor":false,"user":"112.196.52.43","anon":true,"timestamp":"2020-03-10T17:45:04Z","comment":"\/* References *\/"}]}]}}`, pageRevisionsTestTitle, pageRevisionsTestIDS[0], pageRevisionsTestIDS[1])))
 
@@ -39,7 +42,7 @@ func TestPageRevisions(t *testing.T) {
 	client := NewClient(srv.URL)
 	client.options.PageRevisionsURL = pageRevisionsTestURL
 
-	revs, err := client.PageRevisions(context.Background(), pageRevisionsTestTitle, pageRevisionsTestLimit)
+	revs, err := client.PageRevisions(context.Background(), pageRevisionsTestTitle, pageRevisionsTestLimit, pageRevisionsTestOrder)
 
 	assert.Nil(t, err)
 	assert.Equal(t, pageRevisionsTestLimit, len(revs))


### PR DESCRIPTION
Updated `PageRevisions` client's method to support revisions ordering by providing an extra `order` argument.

`go test ./... -cover` output:

```
❯ go test ./... -cover
ok      github.com/protsack-stephan/mediawiki-api-client        0.005s  coverage: 78.3% of statements
?       github.com/protsack-stephan/mediawiki-api-client/example        [no test files]
```