### PR TITLE
Add Options struct to PageVersions request

### DIFF
--- a/client.go
+++ b/client.go
@@ -210,15 +210,23 @@ func (cl *Client) PageWikitext(ctx context.Context, title string, rev ...int) ([
 }
 
 // PageRevisions get list of page revisions.
-func (cl *Client) PageRevisions(ctx context.Context, title string, limit int, order ...RevisionOrdering) ([]Revision, error) {
+func (cl *Client) PageRevisions(ctx context.Context, title string, limit int, options ...PageRevisionsOptions) ([]Revision, error) {
+	var props []string
 	revs := []Revision{}
-
 	ordering := RevisionOrderingOlder
-	if len(order) > 0 {
-		ordering = order[0]
+
+	if len(options) > 0 {
+		opt := options[0]
+		ordering = opt.Order
+		props = opt.Props
 	}
 
-	data, status, err := req(ctx, cl.httpClient, http.MethodGet, cl.url+fmt.Sprintf(cl.options.PageRevisionsURL, limit, ordering, url.QueryEscape(title)), nil)
+	reqURL := cl.url + fmt.Sprintf(cl.options.PageRevisionsURL, limit, ordering, url.QueryEscape(title))
+	if len(props) > 0 {
+		reqURL += fmt.Sprintf("&rvprop=%s", url.QueryEscape(strings.Join(props, "|")))
+	}
+
+	data, status, err := req(ctx, cl.httpClient, http.MethodGet, reqURL, nil)
 
 	if err != nil {
 		return revs, err

--- a/client.go
+++ b/client.go
@@ -221,11 +221,21 @@ func (cl *Client) PageRevisions(ctx context.Context, title string, limit int, op
 		props = opt.Props
 	}
 
-	reqURL := cl.url + fmt.Sprintf(cl.options.PageRevisionsURL, limit, ordering, url.QueryEscape(title))
-	if len(props) > 0 {
-		reqURL += fmt.Sprintf("&rvprop=%s", url.QueryEscape(strings.Join(props, "|")))
+	body := url.Values{
+		"action":        []string{"query"},
+		"format":        []string{"json"},
+		"formatversion": []string{"2"},
+		"prop":          []string{"revisions"},
+		"titles":        []string{url.QueryEscape(title)},
+		"rvlimit":       []string{strconv.Itoa(limit)},
+		"rvdir":         []string{string(ordering)},
 	}
 
+	if len(props) > 0 {
+		body["rvprop"] = []string{strings.Join(props, "|")}
+	}
+
+	reqURL := cl.url + cl.options.PageRevisionsURL + body.Encode()
 	data, status, err := req(ctx, cl.httpClient, http.MethodGet, reqURL, nil)
 
 	if err != nil {

--- a/example/main.go
+++ b/example/main.go
@@ -75,7 +75,10 @@ func main() {
 
 	fmt.Println(string(wikitext))
 
-	psdata, err := client.PagesData(ctx, "Barack_Obama", "Earth")
+	psdata, err := client.PagesData(ctx, []string{"Barack_Obama", "Earth"}, mediawiki.PageDataOptions{
+		RevisionsLimit: 2,
+		RevisionProps:  []string{"ids", "timestamp", "content", "sha1"},
+	})
 
 	if err != nil {
 		log.Panic(err)

--- a/example/main.go
+++ b/example/main.go
@@ -28,7 +28,12 @@ func main() {
 
 	fmt.Println(string(data))
 
-	revisions, err := client.PageRevisions(ctx, "Pet_door", 10, mediawiki.RevisionOrderingOlder)
+	revisions, err := client.PageRevisions(ctx, "Pet_door", 10,
+		mediawiki.PageRevisionsOptions{
+			Order: mediawiki.RevisionOrderingOlder,
+			Props: []string{"content", "ids", "timestamp"},
+		},
+	)
 
 	if err != nil {
 		log.Panic(err)

--- a/page_data.go
+++ b/page_data.go
@@ -4,6 +4,11 @@ import "time"
 
 const pageDataURL = "/w/api.php"
 
+type PageDataOptions struct {
+	RevisionsLimit int
+	RevisionProps  []string
+}
+
 // PageDataOresScore representation for ORES score
 type PageDataOresScore struct {
 	True  float64 `json:"true"`

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -204,7 +204,7 @@ func TestPageData(t *testing.T) {
 	client := NewClient(srv.URL)
 	client.options.PageDataURL = pageDataTestURL
 
-	pages, err := client.PagesData(ctx, pageDataTestTitle, pageDataTestRedirectTitle, pageDataTestMissingTitle)
+	pages, err := client.PagesData(ctx, []string{pageDataTestTitle, pageDataTestRedirectTitle, pageDataTestMissingTitle})
 	assert.NoError(err)
 	assert.Contains(pages, pageDataTestTitle)
 	assert.NotContains(pages, pageDataTestMissingTitle)

--- a/page_revisions.go
+++ b/page_revisions.go
@@ -2,7 +2,13 @@ package mediawiki
 
 import "time"
 
-const revisionsURL = "/w/api.php?action=query&format=json&prop=revisions&rvlimit=%d&rvdir=%s&formatversion=2&titles=%s"
+const revisionsURL = "/w/api.php?action=query&format=json&formatversion=2&prop=revisions&rvlimit=%d&rvdir=%s&titles=%s"
+
+// PageRevisionsOptions additional optional parameters for PageRevisions method
+type PageRevisionsOptions struct {
+	Order RevisionOrdering
+	Props []string
+}
 
 // Revision page revision schema
 type Revision struct {

--- a/page_revisions.go
+++ b/page_revisions.go
@@ -2,7 +2,7 @@ package mediawiki
 
 import "time"
 
-const revisionsURL = "/w/api.php?action=query&format=json&formatversion=2&prop=revisions&rvlimit=%d&rvdir=%s&titles=%s"
+const revisionsURL = "/w/api.php?"
 
 // PageRevisionsOptions additional optional parameters for PageRevisions method
 type PageRevisionsOptions struct {

--- a/page_revisions_test.go
+++ b/page_revisions_test.go
@@ -15,7 +15,6 @@ import (
 var pageRevisionsTestIDS = []int{944917628, 944912305}
 
 const (
-	pageRevisionsTestURL   = "/revisions/%d/%s/%s/%s"
 	pageRevisionsTestTitle = "test"
 	pageRevisionsTestLimit = 2
 	pageRevisionsTestOrder = RevisionOrderingNewer

--- a/page_revisions_test.go
+++ b/page_revisions_test.go
@@ -3,9 +3,10 @@ package mediawiki
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,35 +15,49 @@ import (
 var pageRevisionsTestIDS = []int{944917628, 944912305}
 
 const (
-	pageRevisionsTestURL   = "/revisions/%d/%s/%s"
+	pageRevisionsTestURL   = "/revisions/%d/%s/%s/%s"
 	pageRevisionsTestTitle = "test"
 	pageRevisionsTestLimit = 2
 	pageRevisionsTestOrder = RevisionOrderingNewer
+	pageRevisionsTestProps = "content|ids"
 )
 
-func createPageRevisionsServer() http.Handler {
+func createPageRevisionsServer(t *testing.T) http.Handler {
 	router := http.NewServeMux()
 
-	router.HandleFunc(fmt.Sprintf(pageRevisionsTestURL, pageRevisionsTestLimit, pageRevisionsTestOrder, pageRevisionsTestTitle), func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(fmt.Sprintf(`{"continue":{"rvcontinue":"20200310174438|944912225","continue":"||"},"query":{"normalized":[{"fromencoded":false,"from":"Pet_door","to":"Pet door"}],"pages":[{"pageid":3276454,"ns":0,"title":"%s","revisions":[{"revid":%d,"parentid":944912305,"minor":true,"user":"IdreamofJeanie","timestamp":"2020-03-10T18:17:36Z","comment":"Reverted 2 edits by [[Special:Contributions\/112.196.52.43|112.196.52.43]] ([[User talk:112.196.52.43|talk]]) to last revision by LizzieBabes419 ([[WP:TW|TW]])"},{"revid":%d,"parentid":944912225,"minor":false,"user":"112.196.52.43","anon":true,"timestamp":"2020-03-10T17:45:04Z","comment":"\/* References *\/"}]}]}}`, pageRevisionsTestTitle, pageRevisionsTestIDS[0], pageRevisionsTestIDS[1])))
+	router.HandleFunc("/w/api.php", func(w http.ResponseWriter, r *http.Request) {
+		values, err := url.ParseQuery(r.URL.RawQuery)
+		assert.NoError(t, err)
 
-		if err != nil {
-			log.Panic(err)
-		}
+		assert.True(t, values.Has("titles") && assert.Equal(t, pageRevisionsTestTitle, values.Get("titles")))
+		assert.True(t, values.Has("rvlimit") && assert.Equal(t, strconv.Itoa(pageRevisionsTestLimit), values.Get("rvlimit")))
+		assert.True(t, values.Has("rvdir") && assert.Equal(t, string(pageRevisionsTestOrder), values.Get("rvdir")))
+		assert.True(t, values.Has("rvprop") && assert.Equal(t, pageRevisionsTestProps, values.Get("rvprop")))
+
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write([]byte(fmt.Sprintf(`{"continue":{"rvcontinue":"20200310174438|944912225","continue":"||"},"query":{"normalized":[{"fromencoded":false,"from":"Pet_door","to":"Pet door"}],"pages":[{"pageid":3276454,"ns":0,"title":"%s","revisions":[{"revid":%d,"parentid":944912305,"minor":true,"user":"IdreamofJeanie","timestamp":"2020-03-10T18:17:36Z","comment":"Reverted 2 edits by [[Special:Contributions\/112.196.52.43|112.196.52.43]] ([[User talk:112.196.52.43|talk]]) to last revision by LizzieBabes419 ([[WP:TW|TW]])"},{"revid":%d,"parentid":944912225,"minor":false,"user":"112.196.52.43","anon":true,"timestamp":"2020-03-10T17:45:04Z","comment":"\/* References *\/"}]}]}}`, pageRevisionsTestTitle, pageRevisionsTestIDS[0], pageRevisionsTestIDS[1])))
+
+		assert.NoError(t, err)
 	})
 
 	return router
 }
 
 func TestPageRevisions(t *testing.T) {
-	srv := httptest.NewServer(createPageRevisionsServer())
+	srv := httptest.NewServer(createPageRevisionsServer(t))
 	defer srv.Close()
 
 	client := NewClient(srv.URL)
-	client.options.PageRevisionsURL = pageRevisionsTestURL
 
-	revs, err := client.PageRevisions(context.Background(), pageRevisionsTestTitle, pageRevisionsTestLimit, pageRevisionsTestOrder)
+	revs, err := client.PageRevisions(
+		context.Background(),
+		pageRevisionsTestTitle,
+		pageRevisionsTestLimit,
+		PageRevisionsOptions{
+			Order: pageRevisionsTestOrder,
+			Props: []string{"content", "ids"},
+		},
+	)
 
 	assert.Nil(t, err)
 	assert.Equal(t, pageRevisionsTestLimit, len(revs))


### PR DESCRIPTION
We need to be able to pass optional configurations to `PageData`, `PagesData` and `PageVersions` methods for requests parameters like `order` and `props`.

`PageData` and `PageVersions` methods are no longer compatible with previous versions due to the method signature changed.