### PR TITLE
Added support for hidden prop of page category

### DIFF
--- a/client.go
+++ b/client.go
@@ -80,12 +80,23 @@ func (cl *Client) PageMeta(ctx context.Context, title string) (*PageMeta, error)
 func (cl *Client) PagesData(ctx context.Context, titles []string, options ...PageDataOptions) (map[string]PageData, error) {
 	var rvProps []string
 	rvLimit := 1
+	clLimit := 500
+	clProps := []string{"hidden"}
+
 	pages := make(map[string]PageData)
 	res := new(pageDataResponse)
 
 	for _, opt := range options {
 		rvLimit = opt.RevisionsLimit
 		rvProps = opt.RevisionProps
+
+		if opt.CategoriesLimit > 0 && opt.CategoriesLimit < 500 {
+			clLimit = opt.CategoriesLimit
+		}
+
+		if len(opt.CategoriesProps) > 0 {
+			clProps = opt.CategoriesProps
+		}
 	}
 
 	body := url.Values{
@@ -100,6 +111,8 @@ func (cl *Client) PagesData(ctx context.Context, titles []string, options ...Pag
 		"formatversion": []string{"2"},
 		"format":        []string{"json"},
 		"rvlimit":       []string{fmt.Sprintf("%d", rvLimit)},
+		"cllimit":       []string{fmt.Sprintf("%d", clLimit)},
+		"clprop":        []string{strings.Join(clProps, "|")},
 	}
 
 	if len(rvProps) > 0 {

--- a/example/main.go
+++ b/example/main.go
@@ -125,9 +125,11 @@ func main() {
 	if err != nil {
 		log.Panic(err)
 	}
+
 	if len(pdata.Categories) != 1 {
 		fmt.Println("Error: PageData response should have only one category.")
 	}
+
 	fmt.Println("Category namespace : ", pdata.Categories[0].Ns)
 	fmt.Println("Category title : ", pdata.Categories[0].Title)
 	fmt.Println("Category prop hidden : ", pdata.Categories[0].Hidden)

--- a/example/main.go
+++ b/example/main.go
@@ -114,4 +114,21 @@ func main() {
 	}
 
 	fmt.Println(user)
+
+	// An example of working with page category
+	opt := mediawiki.PageDataOptions{
+		CategoriesLimit: 1,
+		CategoriesProps: []string{"hidden"},
+	}
+	pdata, err = client.PageData(ctx, "Rideau_River", opt)
+
+	if err != nil {
+		log.Panic(err)
+	}
+	if len(pdata.Categories) != 1 {
+		fmt.Println("Error: PageData response should have only one category.")
+	}
+	fmt.Println("Category namespace : ", pdata.Categories[0].Ns)
+	fmt.Println("Category title : ", pdata.Categories[0].Title)
+	fmt.Println("Category prop hidden : ", pdata.Categories[0].Hidden)
 }

--- a/page_data.go
+++ b/page_data.go
@@ -4,9 +4,13 @@ import "time"
 
 const pageDataURL = "/w/api.php"
 
+// PageDataOptions representation of optional arguments to PagesData API.
+// For details on page category props, refer to https://www.mediawiki.org/wiki/API:Categories#API_documentation
 type PageDataOptions struct {
-	RevisionsLimit int
-	RevisionProps  []string
+	RevisionsLimit  int
+	RevisionProps   []string
+	CategoriesLimit int
+	CategoriesProps []string
 }
 
 // PageDataOresScore representation for ORES score
@@ -62,8 +66,9 @@ type PageDataProtection struct {
 
 // PageDataCategory representation for page data category
 type PageDataCategory struct {
-	Ns    int    `json:"ns"`
-	Title string `json:"title"`
+	Ns     int    `json:"ns"`
+	Title  string `json:"title"`
+	Hidden bool   `json:"hidden"`
 }
 
 // PageDataTemplate representation for page data template

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -81,7 +81,7 @@ const pageDataTestBdy = `{
 							"categories": [
 								{
 									"ns": %d,
-									"title": "%s"
+									"title": "%s",
 									"hidden": false
 								}
 							],

--- a/page_data_test.go
+++ b/page_data_test.go
@@ -82,6 +82,7 @@ const pageDataTestBdy = `{
 								{
 									"ns": %d,
 									"title": "%s"
+									"hidden": false
 								}
 							],
 							"revisions": [
@@ -192,6 +193,7 @@ func assertPage(assert *assert.Assertions, page PageData) {
 	assert.Contains(page.WbEntityUsage[pageDataTestWbEntityUsageQID].Aspects, pageDataTestWbEntityUsageAspect)
 	assert.Equal(pageDataTestCategoriesTitle, page.Categories[0].Title)
 	assert.Equal(pageDataTestCategoriesNs, page.Categories[0].Ns)
+	assert.Equal(false, page.Categories[0].Hidden)
 	assert.Equal(pageDataStableRev, page.Flagged.StableRevID)
 }
 


### PR DESCRIPTION
- Updated PageDataOptions to include the number of categories ([cllimit](https://www.mediawiki.org/wiki/API:Categories#API_documentation)) to return and list of category props  ([clprop](https://www.mediawiki.org/wiki/API:Categories#API_documentation)) to return
- Updated PageDataCategory to include [hidden](https://www.mediawiki.org/wiki/API:Categories#API_documentation) prop